### PR TITLE
fixed item payback class in upgrades table

### DIFF
--- a/hamster-autoclicker.user.js
+++ b/hamster-autoclicker.user.js
@@ -4,7 +4,7 @@
 // @match        *://*.hamsterkombat.io/*
 // @match        *://*.hamsterkombatgame.io/*
 // @exclude      https://hamsterkombatgame.io/games/UnblockPuzzle/*
-// @version      3.0
+// @version      3.0.1
 // @grant        none
 // @icon         https://hamsterkombatgame.io/images/icons/hamster-coin.png
 // @downloadURL  https://github.com/mudachyo/Hamster-Kombat/raw/main/hamster-autoclicker.user.js
@@ -603,7 +603,7 @@
 	
 			upgradesForBuy.forEach(item => {
 				const paybackTime = item.profitPerHourDelta ? (item.price / item.profitPerHourDelta) : Infinity;
-				const paybackClass = paybackTime <= 672 ? 'payback-good' : 'payback-bad';
+				const paybackClass = paybackTime <= settings.maxPaybackHours ? 'payback-good' : 'payback-bad';
 				const isAvailable = item.isAvailable && !item.isExpired;
 				const availabilityIcon = isAvailable ? '✅' : '❌';
 				tableContent += `


### PR DESCRIPTION
The text color of `paybackHours` remained red even when the `maxPaybackHours` setting was increased. This issue has been resolved by updating the comparison to use the value from the settings rather than a constant.